### PR TITLE
Done with queue management utils and cron job

### DIFF
--- a/pchaa/.gitattributes
+++ b/pchaa/.gitattributes
@@ -1,6 +1,6 @@
 # Serverpod generated files
-server/lib/src/generated/** linguist-generated=true
-client/lib/src/** linguist-generated=true
+pchaa_server/lib/src/generated/** linguist-generated=true
+pchaa_client/lib/src/** linguist-generated=true
 
 # Migrations (optional – see note below)
-server/migrations/** linguist-generated=true
+pchaa_server/migrations/** linguist-generated=true

--- a/pchaa/pchaa_client/lib/src/protocol/client.dart
+++ b/pchaa/pchaa_client/lib/src/protocol/client.dart
@@ -394,6 +394,21 @@ class EndpointMenuItem extends _i2.EndpointRef {
 }
 
 /// {@category Endpoint}
+class EndpointQueue extends _i2.EndpointRef {
+  EndpointQueue(_i2.EndpointCaller caller) : super(caller);
+
+  @override
+  String get name => 'queue';
+
+  _i3.Future<Map<String, int>> getQueueCounters() =>
+      caller.callServerEndpoint<Map<String, int>>(
+        'queue',
+        'getQueueCounters',
+        {},
+      );
+}
+
+/// {@category Endpoint}
 class EndpointUser extends _i2.EndpointRef {
   EndpointUser(_i2.EndpointCaller caller) : super(caller);
 
@@ -499,6 +514,7 @@ class Client extends _i2.ServerpodClientShared {
     jwtRefresh = EndpointJwtRefresh(this);
     ingredient = EndpointIngredient(this);
     menuItem = EndpointMenuItem(this);
+    queue = EndpointQueue(this);
     user = EndpointUser(this);
     greeting = EndpointGreeting(this);
     modules = Modules(this);
@@ -512,6 +528,8 @@ class Client extends _i2.ServerpodClientShared {
 
   late final EndpointMenuItem menuItem;
 
+  late final EndpointQueue queue;
+
   late final EndpointUser user;
 
   late final EndpointGreeting greeting;
@@ -524,6 +542,7 @@ class Client extends _i2.ServerpodClientShared {
     'jwtRefresh': jwtRefresh,
     'ingredient': ingredient,
     'menuItem': menuItem,
+    'queue': queue,
     'user': user,
     'greeting': greeting,
   };

--- a/pchaa/pchaa_client/lib/src/protocol/protocol.dart
+++ b/pchaa/pchaa_client/lib/src/protocol/protocol.dart
@@ -289,6 +289,12 @@ class Protocol extends _i1.SerializationManager {
               : null)
           as T;
     }
+    if (t == Map<String, int>) {
+      return (data as Map).map(
+            (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)),
+          )
+          as T;
+    }
     if (t == List<_i25.User>) {
       return (data as List).map((e) => deserialize<_i25.User>(e)).toList() as T;
     }

--- a/pchaa/pchaa_server/lib/server.dart
+++ b/pchaa/pchaa_server/lib/server.dart
@@ -1,13 +1,13 @@
 import 'dart:io';
 
 import 'package:serverpod/serverpod.dart';
-import 'package:serverpod_auth_idp_server/core.dart';
-import 'package:serverpod_auth_idp_server/providers/google.dart';
 
 import 'src/generated/endpoints.dart';
 import 'src/generated/protocol.dart';
 import 'src/web/routes/app_config_route.dart';
 import 'src/web/routes/root.dart';
+import 'src/future_calls/reset_queue_call.dart';
+import 'src/utils/thailand_time_utils.dart';
 
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as auth;
 
@@ -66,4 +66,15 @@ void run(List<String> args) async {
 
   // Start the server.
   await pod.start();
+
+  // Register future call for daily queue reset
+  pod.registerFutureCall(ResetQueueCall(), 'resetQueue');
+  var thailandMidnight = ThailandTimeUtils.getNextThailandMidnight();
+
+  await pod.futureCallAtTime(
+    'resetQueue',
+    null,
+    thailandMidnight,
+    identifier: 'dailyQueueReset',
+  );
 }

--- a/pchaa/pchaa_server/lib/src/endpoints/queue_endpoint.dart
+++ b/pchaa/pchaa_server/lib/src/endpoints/queue_endpoint.dart
@@ -1,0 +1,19 @@
+import 'package:serverpod/serverpod.dart';
+import '../generated/protocol.dart';
+import '../utils/thailand_time_utils.dart';
+
+class QueueEndpoint extends Endpoint {
+  Future<Map<String, int>> getQueueCounters(Session session) async {
+    var date = ThailandTimeUtils.getThailandDate();
+    var counter = await DailyQueueCounter.db.findFirstRow(
+      session,
+      where: (t) => t.queueDate.equals(date),
+    );
+
+    if (counter == null) {
+      return {'iCount': 0, 'sCount': 0};
+    }
+
+    return {'iCount': counter.iCount, 'sCount': counter.sCount};
+  }
+}

--- a/pchaa/pchaa_server/lib/src/future_calls/reset_queue_call.dart
+++ b/pchaa/pchaa_server/lib/src/future_calls/reset_queue_call.dart
@@ -1,0 +1,36 @@
+import 'package:serverpod/serverpod.dart';
+import '../generated/daily_queue_counters.dart';
+import '../utils/thailand_time_utils.dart';
+
+class ResetQueueCall extends FutureCall {
+  @override
+  Future<void> invoke(Session session, SerializableModel? object) async {
+    var date = ThailandTimeUtils.getThailandDate();
+
+    var existingCounter = await DailyQueueCounter.db.findFirstRow(
+      session,
+      where: (t) => t.queueDate.equals(date),
+    );
+
+    if (existingCounter != null) {
+      existingCounter.iCount = 0;
+      existingCounter.sCount = 0;
+      await DailyQueueCounter.db.updateRow(session, existingCounter);
+    } else {
+      var newCounter = DailyQueueCounter(
+        queueDate: date,
+        iCount: 0,
+        sCount: 0,
+      );
+      await DailyQueueCounter.db.insert(session, [newCounter]);
+    }
+
+    var nextReset = ThailandTimeUtils.getNextThailandMidnight();
+    await session.serverpod.futureCallAtTime(
+      'resetQueue',
+      null,
+      nextReset,
+      identifier: 'dailyQueueReset',
+    );
+  }
+}

--- a/pchaa/pchaa_server/lib/src/generated/endpoints.dart
+++ b/pchaa/pchaa_server/lib/src/generated/endpoints.dart
@@ -15,15 +15,16 @@ import '../auth/email_idp_endpoint.dart' as _i2;
 import '../auth/jwt_refresh_endpoint.dart' as _i3;
 import '../endpoints/ingredient_endpoint.dart' as _i4;
 import '../endpoints/menu_item_endpoint.dart' as _i5;
-import '../endpoints/user_endpoint.dart' as _i6;
-import '../greetings/greeting_endpoint.dart' as _i7;
-import 'package:pchaa_server/src/generated/customization_group.dart' as _i8;
-import 'package:pchaa_server/src/generated/user_role.dart' as _i9;
+import '../endpoints/queue_endpoint.dart' as _i6;
+import '../endpoints/user_endpoint.dart' as _i7;
+import '../greetings/greeting_endpoint.dart' as _i8;
+import 'package:pchaa_server/src/generated/customization_group.dart' as _i9;
+import 'package:pchaa_server/src/generated/user_role.dart' as _i10;
 import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
-    as _i10;
-import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i11;
+    as _i11;
+import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i12;
 import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
-    as _i12;
+    as _i13;
 
 class Endpoints extends _i1.EndpointDispatch {
   @override
@@ -53,13 +54,19 @@ class Endpoints extends _i1.EndpointDispatch {
           'menuItem',
           null,
         ),
-      'user': _i6.UserEndpoint()
+      'queue': _i6.QueueEndpoint()
+        ..initialize(
+          server,
+          'queue',
+          null,
+        ),
+      'user': _i7.UserEndpoint()
         ..initialize(
           server,
           'user',
           null,
         ),
-      'greeting': _i7.GreetingEndpoint()
+      'greeting': _i8.GreetingEndpoint()
         ..initialize(
           server,
           'greeting',
@@ -394,7 +401,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'customization': _i1.ParameterDescription(
               name: 'customization',
-              type: _i1.getType<List<_i8.CustomizationGroup>>(),
+              type: _i1.getType<List<_i9.CustomizationGroup>>(),
               nullable: false,
             ),
             'isAvailable': _i1.ParameterDescription(
@@ -524,7 +531,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'customization': _i1.ParameterDescription(
               name: 'customization',
-              type: _i1.getType<List<_i8.CustomizationGroup>?>(),
+              type: _i1.getType<List<_i9.CustomizationGroup>?>(),
               nullable: true,
             ),
             'isAvailable': _i1.ParameterDescription(
@@ -599,6 +606,22 @@ class Endpoints extends _i1.EndpointDispatch {
         ),
       },
     );
+    connectors['queue'] = _i1.EndpointConnector(
+      name: 'queue',
+      endpoint: endpoints['queue']!,
+      methodConnectors: {
+        'getQueueCounters': _i1.MethodConnector(
+          name: 'getQueueCounters',
+          params: {},
+          call:
+              (
+                _i1.Session session,
+                Map<String, dynamic> params,
+              ) async => (endpoints['queue'] as _i6.QueueEndpoint)
+                  .getQueueCounters(session),
+        ),
+      },
+    );
     connectors['user'] = _i1.EndpointConnector(
       name: 'user',
       endpoint: endpoints['user']!,
@@ -616,7 +639,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['user'] as _i6.UserEndpoint).registerUser(
+              ) async => (endpoints['user'] as _i7.UserEndpoint).registerUser(
                 session,
                 profilePictureUrl: params['profilePictureUrl'],
               ),
@@ -628,7 +651,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['user'] as _i6.UserEndpoint).getCurrentUser(
+              ) async => (endpoints['user'] as _i7.UserEndpoint).getCurrentUser(
                 session,
               ),
         ),
@@ -640,7 +663,7 @@ class Endpoints extends _i1.EndpointDispatch {
                 _i1.Session session,
                 Map<String, dynamic> params,
               ) async =>
-                  (endpoints['user'] as _i6.UserEndpoint).getAllUser(session),
+                  (endpoints['user'] as _i7.UserEndpoint).getAllUser(session),
         ),
         'updateUserRole': _i1.MethodConnector(
           name: 'updateUserRole',
@@ -652,7 +675,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'newRole': _i1.ParameterDescription(
               name: 'newRole',
-              type: _i1.getType<_i9.UserRole>(),
+              type: _i1.getType<_i10.UserRole>(),
               nullable: false,
             ),
           },
@@ -660,7 +683,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['user'] as _i6.UserEndpoint).updateUserRole(
+              ) async => (endpoints['user'] as _i7.UserEndpoint).updateUserRole(
                 session,
                 params['userId'],
                 params['newRole'],
@@ -685,17 +708,17 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['greeting'] as _i7.GreetingEndpoint).hello(
+              ) async => (endpoints['greeting'] as _i8.GreetingEndpoint).hello(
                 session,
                 params['name'],
               ),
         ),
       },
     );
-    modules['serverpod_auth_idp'] = _i10.Endpoints()
+    modules['serverpod_auth_idp'] = _i11.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth'] = _i11.Endpoints()..initializeEndpoints(server);
-    modules['serverpod_auth_core'] = _i12.Endpoints()
+    modules['serverpod_auth'] = _i12.Endpoints()..initializeEndpoints(server);
+    modules['serverpod_auth_core'] = _i13.Endpoints()
       ..initializeEndpoints(server);
   }
 }

--- a/pchaa/pchaa_server/lib/src/generated/protocol.dart
+++ b/pchaa/pchaa_server/lib/src/generated/protocol.dart
@@ -853,6 +853,12 @@ class Protocol extends _i1.SerializationManagerServer {
               : null)
           as T;
     }
+    if (t == Map<String, int>) {
+      return (data as Map).map(
+            (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)),
+          )
+          as T;
+    }
     if (t == List<_i29.User>) {
       return (data as List).map((e) => deserialize<_i29.User>(e)).toList() as T;
     }

--- a/pchaa/pchaa_server/lib/src/generated/protocol.yaml
+++ b/pchaa/pchaa_server/lib/src/generated/protocol.yaml
@@ -22,6 +22,8 @@ menuItem:
   - getAvailableMenuItemById:
   - updateMenuItem:
   - deleteMenuItem:
+queue:
+  - getQueueCounters:
 user:
   - registerUser:
   - getCurrentUser:

--- a/pchaa/pchaa_server/lib/src/utils/queue_utils.dart
+++ b/pchaa/pchaa_server/lib/src/utils/queue_utils.dart
@@ -1,0 +1,61 @@
+import 'package:serverpod/serverpod.dart';
+import '../generated/daily_queue_counters.dart';
+import 'thailand_time_utils.dart';
+
+class QueueUtils {
+  static Future<int> getLatestQueue(Session session, String type) async {
+    if (type != 'i' && type != 's') {
+      throw ArgumentError('Type must be "i" or "s"');
+    }
+
+    var date = ThailandTimeUtils.getThailandDate();
+
+    var counter = await DailyQueueCounter.db.findFirstRow(
+      session,
+      where: (t) => t.queueDate.equals(date),
+    );
+
+    if (counter == null) {
+      counter = DailyQueueCounter(
+        queueDate: date,
+        iCount: 0,
+        sCount: 0,
+      );
+      await DailyQueueCounter.db.insert(session, [counter]);
+    }
+
+    return type == 'i' ? counter.iCount : counter.sCount;
+  }
+
+  static Future<int> newQueue(Session session, String type) async {
+    if (type != 'i' && type != 's') {
+      throw ArgumentError('Type must be "i" or "s"');
+    }
+
+    var date = ThailandTimeUtils.getThailandDate();
+
+    var counter = await DailyQueueCounter.db.findFirstRow(
+      session,
+      where: (t) => t.queueDate.equals(date),
+    );
+
+    if (counter == null) {
+      counter = DailyQueueCounter(
+        queueDate: date,
+        iCount: 0,
+        sCount: 0,
+      );
+      await DailyQueueCounter.db.insert(session, [counter]);
+    }
+
+    if (type == 'i') {
+      counter.iCount += 1;
+    } else {
+      counter.sCount += 1;
+    }
+
+    await DailyQueueCounter.db.updateRow(session, counter);
+
+    return type == 'i' ? counter.iCount : counter.sCount;
+  }
+}

--- a/pchaa/pchaa_server/lib/src/utils/s3_utils.dart
+++ b/pchaa/pchaa_server/lib/src/utils/s3_utils.dart
@@ -1,5 +1,4 @@
 import 'package:minio/minio.dart';
-import 'package:minio/models.dart';
 import 'package:serverpod/serverpod.dart';
 import 'dart:typed_data';
 import 'dart:io';

--- a/pchaa/pchaa_server/lib/src/utils/thailand_time_utils.dart
+++ b/pchaa/pchaa_server/lib/src/utils/thailand_time_utils.dart
@@ -1,0 +1,18 @@
+class ThailandTimeUtils {
+  static DateTime getThailandDate() {
+    var now = DateTime.now().toUtc();
+    var thailandTime = now.add(const Duration(hours: 7));
+    return DateTime(thailandTime.year, thailandTime.month, thailandTime.day);
+  }
+
+  static DateTime getNextThailandMidnight() {
+    var now = DateTime.now().toUtc();
+    var thailandMidnight = DateTime.utc(now.year, now.month, now.day, 17, 0, 0);
+
+    if (now.isAfter(thailandMidnight)) {
+      thailandMidnight = thailandMidnight.add(const Duration(days: 1));
+    }
+
+    return thailandMidnight;
+  }
+}

--- a/pchaa/pchaa_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/pchaa/pchaa_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -140,6 +140,8 @@ class TestEndpoints {
 
   late final _MenuItemEndpoint menuItem;
 
+  late final _QueueEndpoint queue;
+
   late final _UserEndpoint user;
 
   late final _GreetingEndpoint greeting;
@@ -165,6 +167,10 @@ class _InternalTestEndpoints extends TestEndpoints
       serializationManager,
     );
     menuItem = _MenuItemEndpoint(
+      endpoints,
+      serializationManager,
+    );
+    queue = _QueueEndpoint(
       endpoints,
       serializationManager,
     );
@@ -902,6 +908,47 @@ class _MenuItemEndpoint {
                   _localCallContext.arguments,
                 )
                 as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+}
+
+class _QueueEndpoint {
+  _QueueEndpoint(
+    this._endpointDispatch,
+    this._serializationManager,
+  );
+
+  final _i2.EndpointDispatch _endpointDispatch;
+
+  final _i2.SerializationManager _serializationManager;
+
+  _i3.Future<Map<String, int>> getQueueCounters(
+    _i1.TestSessionBuilder sessionBuilder,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'queue',
+            method: 'getQueueCounters',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'queue',
+          methodName: 'getQueueCounters',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<Map<String, int>>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();


### PR DESCRIPTION
This pull request introduces a new queue management system that tracks and resets daily queue counters, with both server and client-side support. The main changes include adding endpoints and utilities for queue operations, implementing a daily reset mechanism using future calls, and updating the client protocol for the new functionality.

**Queue Management and Daily Reset:**

* Added `QueueEndpoint` with a `getQueueCounters` method to retrieve daily queue counts
* Implemented `ResetQueueCall` as a `FutureCall` to reset queue counters at Thailand midnight and automatically schedule the next reset. Registered this call during server startup.
* Introduced `QueueUtils` with methods for getting and incrementing queue numbers, ensuring daily counters are managed per type (`i` or `s`).

**Time Zone Utilities:**

* Added `ThailandTimeUtils` to consistently handle Thailand-specific date and midnight calculations for queue resets and daily counters.

**Miscellaneous:**

* Adjusted `.gitattributes` and imports for new directory structure and removed unused imports.

Closes: #5