### PR TITLE
fix Order serailizer

### DIFF
--- a/pchaa/pchaa_client/lib/src/protocol/client.dart
+++ b/pchaa/pchaa_client/lib/src/protocol/client.dart
@@ -27,14 +27,16 @@ import 'package:pchaa_client/src/protocol/available_menu_item.dart' as _i12;
 import 'package:pchaa_client/src/protocol/orders.dart' as _i13;
 import 'package:pchaa_client/src/protocol/order_type.dart' as _i14;
 import 'package:pchaa_client/src/protocol/order_status.dart' as _i15;
-import 'package:pchaa_client/src/protocol/order_items.dart' as _i16;
-import 'package:pchaa_client/src/protocol/order_with_user_name.dart' as _i17;
-import 'package:pchaa_client/src/protocol/store_settings.dart' as _i18;
-import 'package:pchaa_client/src/protocol/users.dart' as _i19;
-import 'package:pchaa_client/src/protocol/user_role.dart' as _i20;
-import 'package:pchaa_client/src/protocol/greetings/greeting.dart' as _i21;
-import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i22;
-import 'protocol.dart' as _i23;
+import 'package:pchaa_client/src/protocol/estimated_queue.dart' as _i16;
+import 'package:pchaa_client/src/protocol/order_with_estimated.dart' as _i17;
+import 'package:pchaa_client/src/protocol/order_items.dart' as _i18;
+import 'package:pchaa_client/src/protocol/order_with_user_name.dart' as _i19;
+import 'package:pchaa_client/src/protocol/store_settings.dart' as _i20;
+import 'package:pchaa_client/src/protocol/users.dart' as _i21;
+import 'package:pchaa_client/src/protocol/user_role.dart' as _i22;
+import 'package:pchaa_client/src/protocol/greetings/greeting.dart' as _i23;
+import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i24;
+import 'protocol.dart' as _i25;
 
 /// By extending [EmailIdpBaseEndpoint], the email identity provider endpoints
 /// are made available on the server and enable the corresponding sign-in widget
@@ -554,31 +556,38 @@ class EndpointOrder extends _i2.EndpointRef {
         {},
       );
 
-  _i3.Future<Map<String, int>> getEstimatedQueue() =>
-      caller.callServerEndpoint<Map<String, int>>(
+  _i3.Future<_i16.EstimatedQueue> getEstimatedQueue() =>
+      caller.callServerEndpoint<_i16.EstimatedQueue>(
         'order',
         'getEstimatedQueue',
         {},
       );
 
-  _i3.Future<Map<String, dynamic>> getOrderById(int orderId) =>
-      caller.callServerEndpoint<Map<String, dynamic>>(
+  _i3.Future<_i17.OrderWithEstimated> getOrderById(int orderId) =>
+      caller.callServerEndpoint<_i17.OrderWithEstimated>(
         'order',
         'getOrderById',
         {'orderId': orderId},
       );
 
-  _i3.Future<List<_i16.OrderItem>> getOrderItems(int orderId) =>
-      caller.callServerEndpoint<List<_i16.OrderItem>>(
+  _i3.Future<List<_i18.OrderItem>> getOrderItems(int orderId) =>
+      caller.callServerEndpoint<List<_i18.OrderItem>>(
         'order',
         'getOrderItems',
         {'orderId': orderId},
       );
 
-  _i3.Future<List<_i17.OrderWithUserName>> getTodayOrder() =>
-      caller.callServerEndpoint<List<_i17.OrderWithUserName>>(
+  _i3.Future<List<_i19.OrderWithUserName>> getTodayOrder() =>
+      caller.callServerEndpoint<List<_i19.OrderWithUserName>>(
         'order',
         'getTodayOrder',
+        {},
+      );
+
+  _i3.Future<List<_i19.OrderWithUserName>> getFinishedOrder() =>
+      caller.callServerEndpoint<List<_i19.OrderWithUserName>>(
+        'order',
+        'getFinishedOrder',
         {},
       );
 }
@@ -605,8 +614,8 @@ class EndpointStore extends _i2.EndpointRef {
   @override
   String get name => 'store';
 
-  _i3.Future<_i18.StoreSettings> getStoreSettings() =>
-      caller.callServerEndpoint<_i18.StoreSettings>(
+  _i3.Future<_i20.StoreSettings> getStoreSettings() =>
+      caller.callServerEndpoint<_i20.StoreSettings>(
         'store',
         'getStoreSettings',
         {},
@@ -619,7 +628,7 @@ class EndpointStore extends _i2.EndpointRef {
         {'isOpen': isOpen},
       );
 
-  _i3.Future<void> updateStoreSettings(_i18.StoreSettings storeSettings) =>
+  _i3.Future<void> updateStoreSettings(_i20.StoreSettings storeSettings) =>
       caller.callServerEndpoint<void>(
         'store',
         'updateStoreSettings',
@@ -634,31 +643,31 @@ class EndpointUser extends _i2.EndpointRef {
   @override
   String get name => 'user';
 
-  _i3.Future<_i19.User?> registerUser({String? profilePictureUrl}) =>
-      caller.callServerEndpoint<_i19.User?>(
+  _i3.Future<_i21.User?> registerUser({String? profilePictureUrl}) =>
+      caller.callServerEndpoint<_i21.User?>(
         'user',
         'registerUser',
         {'profilePictureUrl': profilePictureUrl},
       );
 
-  _i3.Future<_i19.User?> getCurrentUser() =>
-      caller.callServerEndpoint<_i19.User?>(
+  _i3.Future<_i21.User?> getCurrentUser() =>
+      caller.callServerEndpoint<_i21.User?>(
         'user',
         'getCurrentUser',
         {},
       );
 
-  _i3.Future<List<_i19.User>?> getAllUser() =>
-      caller.callServerEndpoint<List<_i19.User>?>(
+  _i3.Future<List<_i21.User>?> getAllUser() =>
+      caller.callServerEndpoint<List<_i21.User>?>(
         'user',
         'getAllUser',
         {},
       );
 
-  _i3.Future<_i19.User> updateUserRole(
+  _i3.Future<_i21.User> updateUserRole(
     int userId,
-    _i20.UserRole newRole,
-  ) => caller.callServerEndpoint<_i19.User>(
+    _i22.UserRole newRole,
+  ) => caller.callServerEndpoint<_i21.User>(
     'user',
     'updateUserRole',
     {
@@ -678,8 +687,8 @@ class EndpointGreeting extends _i2.EndpointRef {
   String get name => 'greeting';
 
   /// Returns a personalized greeting message: "Hello {name}".
-  _i3.Future<_i21.Greeting> hello(String name) =>
-      caller.callServerEndpoint<_i21.Greeting>(
+  _i3.Future<_i23.Greeting> hello(String name) =>
+      caller.callServerEndpoint<_i23.Greeting>(
         'greeting',
         'hello',
         {'name': name},
@@ -689,13 +698,13 @@ class EndpointGreeting extends _i2.EndpointRef {
 class Modules {
   Modules(Client client) {
     serverpod_auth_idp = _i1.Caller(client);
-    auth = _i22.Caller(client);
+    auth = _i24.Caller(client);
     serverpod_auth_core = _i4.Caller(client);
   }
 
   late final _i1.Caller serverpod_auth_idp;
 
-  late final _i22.Caller auth;
+  late final _i24.Caller auth;
 
   late final _i4.Caller serverpod_auth_core;
 }
@@ -720,7 +729,7 @@ class Client extends _i2.ServerpodClientShared {
     bool? disconnectStreamsOnLostInternetConnection,
   }) : super(
          host,
-         _i23.Protocol(),
+         _i25.Protocol(),
          securityContext: securityContext,
          streamingConnectionTimeout: streamingConnectionTimeout,
          connectionTimeout: connectionTimeout,

--- a/pchaa/pchaa_client/lib/src/protocol/estimated_queue.dart
+++ b/pchaa/pchaa_client/lib/src/protocol/estimated_queue.dart
@@ -1,0 +1,81 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+
+abstract class EstimatedQueue implements _i1.SerializableModel {
+  EstimatedQueue._({
+    required this.estimatedPrepTime,
+    required this.queueLength,
+  });
+
+  factory EstimatedQueue({
+    required int estimatedPrepTime,
+    required int queueLength,
+  }) = _EstimatedQueueImpl;
+
+  factory EstimatedQueue.fromJson(Map<String, dynamic> jsonSerialization) {
+    return EstimatedQueue(
+      estimatedPrepTime: jsonSerialization['estimatedPrepTime'] as int,
+      queueLength: jsonSerialization['queueLength'] as int,
+    );
+  }
+
+  int estimatedPrepTime;
+
+  int queueLength;
+
+  /// Returns a shallow copy of this [EstimatedQueue]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  EstimatedQueue copyWith({
+    int? estimatedPrepTime,
+    int? queueLength,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'EstimatedQueue',
+      'estimatedPrepTime': estimatedPrepTime,
+      'queueLength': queueLength,
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _EstimatedQueueImpl extends EstimatedQueue {
+  _EstimatedQueueImpl({
+    required int estimatedPrepTime,
+    required int queueLength,
+  }) : super._(
+         estimatedPrepTime: estimatedPrepTime,
+         queueLength: queueLength,
+       );
+
+  /// Returns a shallow copy of this [EstimatedQueue]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  EstimatedQueue copyWith({
+    int? estimatedPrepTime,
+    int? queueLength,
+  }) {
+    return EstimatedQueue(
+      estimatedPrepTime: estimatedPrepTime ?? this.estimatedPrepTime,
+      queueLength: queueLength ?? this.queueLength,
+    );
+  }
+}

--- a/pchaa/pchaa_client/lib/src/protocol/order_with_estimated.dart
+++ b/pchaa/pchaa_client/lib/src/protocol/order_with_estimated.dart
@@ -1,0 +1,113 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'orders.dart' as _i2;
+import 'order_items.dart' as _i3;
+import 'package:pchaa_client/src/protocol/protocol.dart' as _i4;
+
+abstract class OrderWithEstimated implements _i1.SerializableModel {
+  OrderWithEstimated._({
+    required this.order,
+    required this.orderItems,
+    this.estimatedPrepTime,
+    this.queueLength,
+  });
+
+  factory OrderWithEstimated({
+    required _i2.Order order,
+    required List<_i3.OrderItem> orderItems,
+    int? estimatedPrepTime,
+    int? queueLength,
+  }) = _OrderWithEstimatedImpl;
+
+  factory OrderWithEstimated.fromJson(Map<String, dynamic> jsonSerialization) {
+    return OrderWithEstimated(
+      order: _i4.Protocol().deserialize<_i2.Order>(jsonSerialization['order']),
+      orderItems: _i4.Protocol().deserialize<List<_i3.OrderItem>>(
+        jsonSerialization['orderItems'],
+      ),
+      estimatedPrepTime: jsonSerialization['estimatedPrepTime'] as int?,
+      queueLength: jsonSerialization['queueLength'] as int?,
+    );
+  }
+
+  _i2.Order order;
+
+  List<_i3.OrderItem> orderItems;
+
+  int? estimatedPrepTime;
+
+  int? queueLength;
+
+  /// Returns a shallow copy of this [OrderWithEstimated]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  OrderWithEstimated copyWith({
+    _i2.Order? order,
+    List<_i3.OrderItem>? orderItems,
+    int? estimatedPrepTime,
+    int? queueLength,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'OrderWithEstimated',
+      'order': order.toJson(),
+      'orderItems': orderItems.toJson(valueToJson: (v) => v.toJson()),
+      if (estimatedPrepTime != null) 'estimatedPrepTime': estimatedPrepTime,
+      if (queueLength != null) 'queueLength': queueLength,
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _OrderWithEstimatedImpl extends OrderWithEstimated {
+  _OrderWithEstimatedImpl({
+    required _i2.Order order,
+    required List<_i3.OrderItem> orderItems,
+    int? estimatedPrepTime,
+    int? queueLength,
+  }) : super._(
+         order: order,
+         orderItems: orderItems,
+         estimatedPrepTime: estimatedPrepTime,
+         queueLength: queueLength,
+       );
+
+  /// Returns a shallow copy of this [OrderWithEstimated]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  OrderWithEstimated copyWith({
+    _i2.Order? order,
+    List<_i3.OrderItem>? orderItems,
+    Object? estimatedPrepTime = _Undefined,
+    Object? queueLength = _Undefined,
+  }) {
+    return OrderWithEstimated(
+      order: order ?? this.order.copyWith(),
+      orderItems:
+          orderItems ?? this.orderItems.map((e0) => e0.copyWith()).toList(),
+      estimatedPrepTime: estimatedPrepTime is int?
+          ? estimatedPrepTime
+          : this.estimatedPrepTime,
+      queueLength: queueLength is int? ? queueLength : this.queueLength,
+    );
+  }
+}

--- a/pchaa/pchaa_client/lib/src/protocol/protocol.dart
+++ b/pchaa/pchaa_client/lib/src/protocol/protocol.dart
@@ -19,35 +19,37 @@ import 'cart_detail.dart' as _i6;
 import 'carts.dart' as _i7;
 import 'customization_group.dart' as _i8;
 import 'daily_queue_counters.dart' as _i9;
-import 'fcm_token.dart' as _i10;
-import 'greetings/greeting.dart' as _i11;
-import 'ingredient.dart' as _i12;
-import 'menu_item_with_url.dart' as _i13;
-import 'menu_items.dart' as _i14;
-import 'order_items.dart' as _i15;
-import 'order_status.dart' as _i16;
-import 'order_type.dart' as _i17;
-import 'order_with_user_name.dart' as _i18;
-import 'orders.dart' as _i19;
-import 'selected_option.dart' as _i20;
-import 'store_settings.dart' as _i21;
-import 'user_role.dart' as _i22;
-import 'users.dart' as _i23;
-import 'package:pchaa_client/src/protocol/cart_detail.dart' as _i24;
-import 'package:pchaa_client/src/protocol/selected_option.dart' as _i25;
-import 'package:pchaa_client/src/protocol/ingredient.dart' as _i26;
-import 'package:pchaa_client/src/protocol/customization_group.dart' as _i27;
-import 'package:pchaa_client/src/protocol/menu_item_with_url.dart' as _i28;
-import 'package:pchaa_client/src/protocol/available_menu_item.dart' as _i29;
-import 'package:pchaa_client/src/protocol/orders.dart' as _i30;
-import 'package:pchaa_client/src/protocol/order_items.dart' as _i31;
-import 'package:pchaa_client/src/protocol/order_with_user_name.dart' as _i32;
-import 'package:pchaa_client/src/protocol/users.dart' as _i33;
+import 'estimated_queue.dart' as _i10;
+import 'fcm_token.dart' as _i11;
+import 'greetings/greeting.dart' as _i12;
+import 'ingredient.dart' as _i13;
+import 'menu_item_with_url.dart' as _i14;
+import 'menu_items.dart' as _i15;
+import 'order_items.dart' as _i16;
+import 'order_status.dart' as _i17;
+import 'order_type.dart' as _i18;
+import 'order_with_estimated.dart' as _i19;
+import 'order_with_user_name.dart' as _i20;
+import 'orders.dart' as _i21;
+import 'selected_option.dart' as _i22;
+import 'store_settings.dart' as _i23;
+import 'user_role.dart' as _i24;
+import 'users.dart' as _i25;
+import 'package:pchaa_client/src/protocol/cart_detail.dart' as _i26;
+import 'package:pchaa_client/src/protocol/selected_option.dart' as _i27;
+import 'package:pchaa_client/src/protocol/ingredient.dart' as _i28;
+import 'package:pchaa_client/src/protocol/customization_group.dart' as _i29;
+import 'package:pchaa_client/src/protocol/menu_item_with_url.dart' as _i30;
+import 'package:pchaa_client/src/protocol/available_menu_item.dart' as _i31;
+import 'package:pchaa_client/src/protocol/orders.dart' as _i32;
+import 'package:pchaa_client/src/protocol/order_items.dart' as _i33;
+import 'package:pchaa_client/src/protocol/order_with_user_name.dart' as _i34;
+import 'package:pchaa_client/src/protocol/users.dart' as _i35;
 import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
-    as _i34;
-import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i35;
-import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
     as _i36;
+import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i37;
+import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
+    as _i38;
 export 'add_on_option.dart';
 export 'available_add_on_option.dart';
 export 'available_customization_group.dart';
@@ -56,6 +58,7 @@ export 'cart_detail.dart';
 export 'carts.dart';
 export 'customization_group.dart';
 export 'daily_queue_counters.dart';
+export 'estimated_queue.dart';
 export 'fcm_token.dart';
 export 'greetings/greeting.dart';
 export 'ingredient.dart';
@@ -64,6 +67,7 @@ export 'menu_items.dart';
 export 'order_items.dart';
 export 'order_status.dart';
 export 'order_type.dart';
+export 'order_with_estimated.dart';
 export 'order_with_user_name.dart';
 export 'orders.dart';
 export 'selected_option.dart';
@@ -130,47 +134,53 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i9.DailyQueueCounter) {
       return _i9.DailyQueueCounter.fromJson(data) as T;
     }
-    if (t == _i10.FcmToken) {
-      return _i10.FcmToken.fromJson(data) as T;
+    if (t == _i10.EstimatedQueue) {
+      return _i10.EstimatedQueue.fromJson(data) as T;
     }
-    if (t == _i11.Greeting) {
-      return _i11.Greeting.fromJson(data) as T;
+    if (t == _i11.FcmToken) {
+      return _i11.FcmToken.fromJson(data) as T;
     }
-    if (t == _i12.Ingredient) {
-      return _i12.Ingredient.fromJson(data) as T;
+    if (t == _i12.Greeting) {
+      return _i12.Greeting.fromJson(data) as T;
     }
-    if (t == _i13.MenuItemWithUrl) {
-      return _i13.MenuItemWithUrl.fromJson(data) as T;
+    if (t == _i13.Ingredient) {
+      return _i13.Ingredient.fromJson(data) as T;
     }
-    if (t == _i14.MenuItem) {
-      return _i14.MenuItem.fromJson(data) as T;
+    if (t == _i14.MenuItemWithUrl) {
+      return _i14.MenuItemWithUrl.fromJson(data) as T;
     }
-    if (t == _i15.OrderItem) {
-      return _i15.OrderItem.fromJson(data) as T;
+    if (t == _i15.MenuItem) {
+      return _i15.MenuItem.fromJson(data) as T;
     }
-    if (t == _i16.OrderStatus) {
-      return _i16.OrderStatus.fromJson(data) as T;
+    if (t == _i16.OrderItem) {
+      return _i16.OrderItem.fromJson(data) as T;
     }
-    if (t == _i17.OrderType) {
-      return _i17.OrderType.fromJson(data) as T;
+    if (t == _i17.OrderStatus) {
+      return _i17.OrderStatus.fromJson(data) as T;
     }
-    if (t == _i18.OrderWithUserName) {
-      return _i18.OrderWithUserName.fromJson(data) as T;
+    if (t == _i18.OrderType) {
+      return _i18.OrderType.fromJson(data) as T;
     }
-    if (t == _i19.Order) {
-      return _i19.Order.fromJson(data) as T;
+    if (t == _i19.OrderWithEstimated) {
+      return _i19.OrderWithEstimated.fromJson(data) as T;
     }
-    if (t == _i20.SelectedOption) {
-      return _i20.SelectedOption.fromJson(data) as T;
+    if (t == _i20.OrderWithUserName) {
+      return _i20.OrderWithUserName.fromJson(data) as T;
     }
-    if (t == _i21.StoreSettings) {
-      return _i21.StoreSettings.fromJson(data) as T;
+    if (t == _i21.Order) {
+      return _i21.Order.fromJson(data) as T;
     }
-    if (t == _i22.UserRole) {
-      return _i22.UserRole.fromJson(data) as T;
+    if (t == _i22.SelectedOption) {
+      return _i22.SelectedOption.fromJson(data) as T;
     }
-    if (t == _i23.User) {
-      return _i23.User.fromJson(data) as T;
+    if (t == _i23.StoreSettings) {
+      return _i23.StoreSettings.fromJson(data) as T;
+    }
+    if (t == _i24.UserRole) {
+      return _i24.UserRole.fromJson(data) as T;
+    }
+    if (t == _i25.User) {
+      return _i25.User.fromJson(data) as T;
     }
     if (t == _i1.getType<_i2.AddOnOption?>()) {
       return (data != null ? _i2.AddOnOption.fromJson(data) : null) as T;
@@ -200,47 +210,54 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<_i9.DailyQueueCounter?>()) {
       return (data != null ? _i9.DailyQueueCounter.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i10.FcmToken?>()) {
-      return (data != null ? _i10.FcmToken.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i10.EstimatedQueue?>()) {
+      return (data != null ? _i10.EstimatedQueue.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i11.Greeting?>()) {
-      return (data != null ? _i11.Greeting.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i11.FcmToken?>()) {
+      return (data != null ? _i11.FcmToken.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i12.Ingredient?>()) {
-      return (data != null ? _i12.Ingredient.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i12.Greeting?>()) {
+      return (data != null ? _i12.Greeting.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i13.MenuItemWithUrl?>()) {
-      return (data != null ? _i13.MenuItemWithUrl.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i13.Ingredient?>()) {
+      return (data != null ? _i13.Ingredient.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i14.MenuItem?>()) {
-      return (data != null ? _i14.MenuItem.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i14.MenuItemWithUrl?>()) {
+      return (data != null ? _i14.MenuItemWithUrl.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i15.OrderItem?>()) {
-      return (data != null ? _i15.OrderItem.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i15.MenuItem?>()) {
+      return (data != null ? _i15.MenuItem.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i16.OrderStatus?>()) {
-      return (data != null ? _i16.OrderStatus.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i16.OrderItem?>()) {
+      return (data != null ? _i16.OrderItem.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i17.OrderType?>()) {
-      return (data != null ? _i17.OrderType.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i17.OrderStatus?>()) {
+      return (data != null ? _i17.OrderStatus.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i18.OrderWithUserName?>()) {
-      return (data != null ? _i18.OrderWithUserName.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i18.OrderType?>()) {
+      return (data != null ? _i18.OrderType.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i19.Order?>()) {
-      return (data != null ? _i19.Order.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i19.OrderWithEstimated?>()) {
+      return (data != null ? _i19.OrderWithEstimated.fromJson(data) : null)
+          as T;
     }
-    if (t == _i1.getType<_i20.SelectedOption?>()) {
-      return (data != null ? _i20.SelectedOption.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i20.OrderWithUserName?>()) {
+      return (data != null ? _i20.OrderWithUserName.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i21.StoreSettings?>()) {
-      return (data != null ? _i21.StoreSettings.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i21.Order?>()) {
+      return (data != null ? _i21.Order.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i22.UserRole?>()) {
-      return (data != null ? _i22.UserRole.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i22.SelectedOption?>()) {
+      return (data != null ? _i22.SelectedOption.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i23.User?>()) {
-      return (data != null ? _i23.User.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i23.StoreSettings?>()) {
+      return (data != null ? _i23.StoreSettings.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i24.UserRole?>()) {
+      return (data != null ? _i24.UserRole.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i25.User?>()) {
+      return (data != null ? _i25.User.fromJson(data) : null) as T;
     }
     if (t == List<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toList() as T;
@@ -263,9 +280,9 @@ class Protocol extends _i1.SerializationManager {
               .toList()
           as T;
     }
-    if (t == List<_i20.SelectedOption>) {
+    if (t == List<_i22.SelectedOption>) {
       return (data as List)
-              .map((e) => deserialize<_i20.SelectedOption>(e))
+              .map((e) => deserialize<_i22.SelectedOption>(e))
               .toList()
           as T;
     }
@@ -279,23 +296,27 @@ class Protocol extends _i1.SerializationManager {
               .toList()
           as T;
     }
-    if (t == List<_i24.CartDetail>) {
-      return (data as List).map((e) => deserialize<_i24.CartDetail>(e)).toList()
+    if (t == List<_i16.OrderItem>) {
+      return (data as List).map((e) => deserialize<_i16.OrderItem>(e)).toList()
           as T;
     }
-    if (t == List<_i25.SelectedOption>) {
+    if (t == List<_i26.CartDetail>) {
+      return (data as List).map((e) => deserialize<_i26.CartDetail>(e)).toList()
+          as T;
+    }
+    if (t == List<_i27.SelectedOption>) {
       return (data as List)
-              .map((e) => deserialize<_i25.SelectedOption>(e))
+              .map((e) => deserialize<_i27.SelectedOption>(e))
               .toList()
           as T;
     }
-    if (t == List<_i26.Ingredient>) {
-      return (data as List).map((e) => deserialize<_i26.Ingredient>(e)).toList()
+    if (t == List<_i28.Ingredient>) {
+      return (data as List).map((e) => deserialize<_i28.Ingredient>(e)).toList()
           as T;
     }
-    if (t == List<_i27.CustomizationGroup>) {
+    if (t == List<_i29.CustomizationGroup>) {
       return (data as List)
-              .map((e) => deserialize<_i27.CustomizationGroup>(e))
+              .map((e) => deserialize<_i29.CustomizationGroup>(e))
               .toList()
           as T;
     }
@@ -308,28 +329,38 @@ class Protocol extends _i1.SerializationManager {
               : null)
           as T;
     }
-    if (t == List<_i28.MenuItemWithUrl>) {
+    if (t == List<_i30.MenuItemWithUrl>) {
       return (data as List)
-              .map((e) => deserialize<_i28.MenuItemWithUrl>(e))
+              .map((e) => deserialize<_i30.MenuItemWithUrl>(e))
               .toList()
           as T;
     }
-    if (t == List<_i29.AvailableMenuItem>) {
+    if (t == List<_i31.AvailableMenuItem>) {
       return (data as List)
-              .map((e) => deserialize<_i29.AvailableMenuItem>(e))
+              .map((e) => deserialize<_i31.AvailableMenuItem>(e))
               .toList()
           as T;
     }
-    if (t == _i1.getType<List<_i27.CustomizationGroup>?>()) {
+    if (t == _i1.getType<List<_i29.CustomizationGroup>?>()) {
       return (data != null
               ? (data as List)
-                    .map((e) => deserialize<_i27.CustomizationGroup>(e))
+                    .map((e) => deserialize<_i29.CustomizationGroup>(e))
                     .toList()
               : null)
           as T;
     }
-    if (t == List<_i30.Order>) {
-      return (data as List).map((e) => deserialize<_i30.Order>(e)).toList()
+    if (t == List<_i32.Order>) {
+      return (data as List).map((e) => deserialize<_i32.Order>(e)).toList()
+          as T;
+    }
+    if (t == List<_i33.OrderItem>) {
+      return (data as List).map((e) => deserialize<_i33.OrderItem>(e)).toList()
+          as T;
+    }
+    if (t == List<_i34.OrderWithUserName>) {
+      return (data as List)
+              .map((e) => deserialize<_i34.OrderWithUserName>(e))
+              .toList()
           as T;
     }
     if (t == Map<String, int>) {
@@ -338,39 +369,23 @@ class Protocol extends _i1.SerializationManager {
           )
           as T;
     }
-    if (t == Map<String, dynamic>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<dynamic>(v)),
-          )
-          as T;
+    if (t == List<_i35.User>) {
+      return (data as List).map((e) => deserialize<_i35.User>(e)).toList() as T;
     }
-    if (t == List<_i31.OrderItem>) {
-      return (data as List).map((e) => deserialize<_i31.OrderItem>(e)).toList()
-          as T;
-    }
-    if (t == List<_i32.OrderWithUserName>) {
-      return (data as List)
-              .map((e) => deserialize<_i32.OrderWithUserName>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i33.User>) {
-      return (data as List).map((e) => deserialize<_i33.User>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<_i33.User>?>()) {
+    if (t == _i1.getType<List<_i35.User>?>()) {
       return (data != null
-              ? (data as List).map((e) => deserialize<_i33.User>(e)).toList()
+              ? (data as List).map((e) => deserialize<_i35.User>(e)).toList()
               : null)
           as T;
     }
     try {
-      return _i34.Protocol().deserialize<T>(data, t);
-    } on _i1.DeserializationTypeNotFoundException catch (_) {}
-    try {
-      return _i35.Protocol().deserialize<T>(data, t);
-    } on _i1.DeserializationTypeNotFoundException catch (_) {}
-    try {
       return _i36.Protocol().deserialize<T>(data, t);
+    } on _i1.DeserializationTypeNotFoundException catch (_) {}
+    try {
+      return _i37.Protocol().deserialize<T>(data, t);
+    } on _i1.DeserializationTypeNotFoundException catch (_) {}
+    try {
+      return _i38.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -385,20 +400,22 @@ class Protocol extends _i1.SerializationManager {
       _i7.Cart => 'Cart',
       _i8.CustomizationGroup => 'CustomizationGroup',
       _i9.DailyQueueCounter => 'DailyQueueCounter',
-      _i10.FcmToken => 'FcmToken',
-      _i11.Greeting => 'Greeting',
-      _i12.Ingredient => 'Ingredient',
-      _i13.MenuItemWithUrl => 'MenuItemWithUrl',
-      _i14.MenuItem => 'MenuItem',
-      _i15.OrderItem => 'OrderItem',
-      _i16.OrderStatus => 'OrderStatus',
-      _i17.OrderType => 'OrderType',
-      _i18.OrderWithUserName => 'OrderWithUserName',
-      _i19.Order => 'Order',
-      _i20.SelectedOption => 'SelectedOption',
-      _i21.StoreSettings => 'StoreSettings',
-      _i22.UserRole => 'UserRole',
-      _i23.User => 'User',
+      _i10.EstimatedQueue => 'EstimatedQueue',
+      _i11.FcmToken => 'FcmToken',
+      _i12.Greeting => 'Greeting',
+      _i13.Ingredient => 'Ingredient',
+      _i14.MenuItemWithUrl => 'MenuItemWithUrl',
+      _i15.MenuItem => 'MenuItem',
+      _i16.OrderItem => 'OrderItem',
+      _i17.OrderStatus => 'OrderStatus',
+      _i18.OrderType => 'OrderType',
+      _i19.OrderWithEstimated => 'OrderWithEstimated',
+      _i20.OrderWithUserName => 'OrderWithUserName',
+      _i21.Order => 'Order',
+      _i22.SelectedOption => 'SelectedOption',
+      _i23.StoreSettings => 'StoreSettings',
+      _i24.UserRole => 'UserRole',
+      _i25.User => 'User',
       _ => null,
     };
   }
@@ -429,44 +446,48 @@ class Protocol extends _i1.SerializationManager {
         return 'CustomizationGroup';
       case _i9.DailyQueueCounter():
         return 'DailyQueueCounter';
-      case _i10.FcmToken():
+      case _i10.EstimatedQueue():
+        return 'EstimatedQueue';
+      case _i11.FcmToken():
         return 'FcmToken';
-      case _i11.Greeting():
+      case _i12.Greeting():
         return 'Greeting';
-      case _i12.Ingredient():
+      case _i13.Ingredient():
         return 'Ingredient';
-      case _i13.MenuItemWithUrl():
+      case _i14.MenuItemWithUrl():
         return 'MenuItemWithUrl';
-      case _i14.MenuItem():
+      case _i15.MenuItem():
         return 'MenuItem';
-      case _i15.OrderItem():
+      case _i16.OrderItem():
         return 'OrderItem';
-      case _i16.OrderStatus():
+      case _i17.OrderStatus():
         return 'OrderStatus';
-      case _i17.OrderType():
+      case _i18.OrderType():
         return 'OrderType';
-      case _i18.OrderWithUserName():
+      case _i19.OrderWithEstimated():
+        return 'OrderWithEstimated';
+      case _i20.OrderWithUserName():
         return 'OrderWithUserName';
-      case _i19.Order():
+      case _i21.Order():
         return 'Order';
-      case _i20.SelectedOption():
+      case _i22.SelectedOption():
         return 'SelectedOption';
-      case _i21.StoreSettings():
+      case _i23.StoreSettings():
         return 'StoreSettings';
-      case _i22.UserRole():
+      case _i24.UserRole():
         return 'UserRole';
-      case _i23.User():
+      case _i25.User():
         return 'User';
     }
-    className = _i34.Protocol().getClassNameForObject(data);
+    className = _i36.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth_idp.$className';
     }
-    className = _i35.Protocol().getClassNameForObject(data);
+    className = _i37.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    className = _i36.Protocol().getClassNameForObject(data);
+    className = _i38.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth_core.$className';
     }
@@ -503,59 +524,65 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'DailyQueueCounter') {
       return deserialize<_i9.DailyQueueCounter>(data['data']);
     }
+    if (dataClassName == 'EstimatedQueue') {
+      return deserialize<_i10.EstimatedQueue>(data['data']);
+    }
     if (dataClassName == 'FcmToken') {
-      return deserialize<_i10.FcmToken>(data['data']);
+      return deserialize<_i11.FcmToken>(data['data']);
     }
     if (dataClassName == 'Greeting') {
-      return deserialize<_i11.Greeting>(data['data']);
+      return deserialize<_i12.Greeting>(data['data']);
     }
     if (dataClassName == 'Ingredient') {
-      return deserialize<_i12.Ingredient>(data['data']);
+      return deserialize<_i13.Ingredient>(data['data']);
     }
     if (dataClassName == 'MenuItemWithUrl') {
-      return deserialize<_i13.MenuItemWithUrl>(data['data']);
+      return deserialize<_i14.MenuItemWithUrl>(data['data']);
     }
     if (dataClassName == 'MenuItem') {
-      return deserialize<_i14.MenuItem>(data['data']);
+      return deserialize<_i15.MenuItem>(data['data']);
     }
     if (dataClassName == 'OrderItem') {
-      return deserialize<_i15.OrderItem>(data['data']);
+      return deserialize<_i16.OrderItem>(data['data']);
     }
     if (dataClassName == 'OrderStatus') {
-      return deserialize<_i16.OrderStatus>(data['data']);
+      return deserialize<_i17.OrderStatus>(data['data']);
     }
     if (dataClassName == 'OrderType') {
-      return deserialize<_i17.OrderType>(data['data']);
+      return deserialize<_i18.OrderType>(data['data']);
+    }
+    if (dataClassName == 'OrderWithEstimated') {
+      return deserialize<_i19.OrderWithEstimated>(data['data']);
     }
     if (dataClassName == 'OrderWithUserName') {
-      return deserialize<_i18.OrderWithUserName>(data['data']);
+      return deserialize<_i20.OrderWithUserName>(data['data']);
     }
     if (dataClassName == 'Order') {
-      return deserialize<_i19.Order>(data['data']);
+      return deserialize<_i21.Order>(data['data']);
     }
     if (dataClassName == 'SelectedOption') {
-      return deserialize<_i20.SelectedOption>(data['data']);
+      return deserialize<_i22.SelectedOption>(data['data']);
     }
     if (dataClassName == 'StoreSettings') {
-      return deserialize<_i21.StoreSettings>(data['data']);
+      return deserialize<_i23.StoreSettings>(data['data']);
     }
     if (dataClassName == 'UserRole') {
-      return deserialize<_i22.UserRole>(data['data']);
+      return deserialize<_i24.UserRole>(data['data']);
     }
     if (dataClassName == 'User') {
-      return deserialize<_i23.User>(data['data']);
+      return deserialize<_i25.User>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_auth_idp.')) {
       data['className'] = dataClassName.substring(19);
-      return _i34.Protocol().deserializeByClassName(data);
+      return _i36.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth.')) {
       data['className'] = dataClassName.substring(15);
-      return _i35.Protocol().deserializeByClassName(data);
+      return _i37.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth_core.')) {
       data['className'] = dataClassName.substring(20);
-      return _i36.Protocol().deserializeByClassName(data);
+      return _i38.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
   }

--- a/pchaa/pchaa_server/lib/src/endpoints/order_endpoint.dart
+++ b/pchaa/pchaa_server/lib/src/endpoints/order_endpoint.dart
@@ -180,12 +180,15 @@ class OrderEndpoint extends Endpoint {
     session.log("[OrderEndpoint] Fetched orders for userId: ${user.id}");
     return orders;
   }
-  Future <Map<String, int>> getEstimatedQueue(Session session) async {
+  Future<EstimatedQueue> getEstimatedQueue(Session session) async {
     await AuthUtils.allowedRoles(session, [UserRole.user, UserRole.owner]);
     var result = await OrderUtils.getEstimatedTimeForNewOrder(session);
-    return result;
+    return EstimatedQueue(
+      estimatedPrepTime: result['estimatedPrepTime']!,
+      queueLength: result['queueLength']!,
+    );
   }
-  Future<Map<String, dynamic>> getOrderById(Session session, int orderId) async {
+  Future<OrderWithEstimated> getOrderById(Session session, int orderId) async {
     final user = await AuthUtils.allowedRoles(session, [UserRole.user, UserRole.owner]);
     
     final order = await Order.db.findById(session, orderId);
@@ -200,16 +203,20 @@ class OrderEndpoint extends Endpoint {
       session,
       where: (t) => t.orderId.equals(orderId),
     );
-    var result = <String, dynamic>{};
-    result['order'] = order;
-    result['orderItems'] = orderItems;
+    int? estimatedPrepTime;
+    int? queueLength;
     if (order.type == OrderType.I && order.queueNumber != null && (order.status == OrderStatus.preparing || order.status == OrderStatus.confirmed)) {
       var estimated = await OrderUtils.calculateEstimatedPrepTime(session, orderId);
-      result['estimatedPrepTime'] = estimated['estimatedPrepTime'];
-      result['queueLength'] = estimated['queueLength'];
+      estimatedPrepTime = estimated['estimatedPrepTime'];
+      queueLength = estimated['queueLength'];
     }
     session.log("[OrderEndpoint] Fetched order with id: $orderId for userId: ${user.id}");
-    return result;
+    return OrderWithEstimated(
+      order: order,
+      orderItems: orderItems,
+      estimatedPrepTime: estimatedPrepTime,
+      queueLength: queueLength,
+    );
   }
 
   Future<List<OrderItem>> getOrderItems(Session session, int orderId) async {
@@ -278,6 +285,29 @@ class OrderEndpoint extends Endpoint {
     }
 
     session.log("[OrderEndpoint] Fetched today's order for date: $today");
+    return result;
+  }
+
+  Future<List<OrderWithUserName>> getFinishedOrder(Session session) async {
+    
+    final today = ThailandTimeUtils.getThailandDate();
+    final finishedOrders = await Order.db.find(
+      session,
+      where: (t) => t.orderDate.equals(today) & t.status.equals(OrderStatus.finished),
+      orderBy: (order) => order.queueNumber,
+    );
+
+    // Fetch user data for each order
+    var result = <OrderWithUserName>[];
+    for (var order in finishedOrders) {
+      final user = await User.db.findById(session, order.userId);
+      result.add(OrderWithUserName(
+        order: order,
+        userName: user?.fullName ?? 'Unknown User',
+      ));
+    }
+
+    session.log("[OrderEndpoint] Fetched finished orders for date: $today");
     return result;
   }
 

--- a/pchaa/pchaa_server/lib/src/generated/endpoints.dart
+++ b/pchaa/pchaa_server/lib/src/generated/endpoints.dart
@@ -996,6 +996,16 @@ class Endpoints extends _i1.EndpointDispatch {
               ) async => (endpoints['order'] as _i8.OrderEndpoint)
                   .getTodayOrder(session),
         ),
+        'getFinishedOrder': _i1.MethodConnector(
+          name: 'getFinishedOrder',
+          params: {},
+          call:
+              (
+                _i1.Session session,
+                Map<String, dynamic> params,
+              ) async => (endpoints['order'] as _i8.OrderEndpoint)
+                  .getFinishedOrder(session),
+        ),
       },
     );
     connectors['queue'] = _i1.EndpointConnector(

--- a/pchaa/pchaa_server/lib/src/generated/estimated_queue.dart
+++ b/pchaa/pchaa_server/lib/src/generated/estimated_queue.dart
@@ -1,0 +1,91 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+abstract class EstimatedQueue
+    implements _i1.SerializableModel, _i1.ProtocolSerialization {
+  EstimatedQueue._({
+    required this.estimatedPrepTime,
+    required this.queueLength,
+  });
+
+  factory EstimatedQueue({
+    required int estimatedPrepTime,
+    required int queueLength,
+  }) = _EstimatedQueueImpl;
+
+  factory EstimatedQueue.fromJson(Map<String, dynamic> jsonSerialization) {
+    return EstimatedQueue(
+      estimatedPrepTime: jsonSerialization['estimatedPrepTime'] as int,
+      queueLength: jsonSerialization['queueLength'] as int,
+    );
+  }
+
+  int estimatedPrepTime;
+
+  int queueLength;
+
+  /// Returns a shallow copy of this [EstimatedQueue]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  EstimatedQueue copyWith({
+    int? estimatedPrepTime,
+    int? queueLength,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'EstimatedQueue',
+      'estimatedPrepTime': estimatedPrepTime,
+      'queueLength': queueLength,
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {
+      '__className__': 'EstimatedQueue',
+      'estimatedPrepTime': estimatedPrepTime,
+      'queueLength': queueLength,
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _EstimatedQueueImpl extends EstimatedQueue {
+  _EstimatedQueueImpl({
+    required int estimatedPrepTime,
+    required int queueLength,
+  }) : super._(
+         estimatedPrepTime: estimatedPrepTime,
+         queueLength: queueLength,
+       );
+
+  /// Returns a shallow copy of this [EstimatedQueue]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  EstimatedQueue copyWith({
+    int? estimatedPrepTime,
+    int? queueLength,
+  }) {
+    return EstimatedQueue(
+      estimatedPrepTime: estimatedPrepTime ?? this.estimatedPrepTime,
+      queueLength: queueLength ?? this.queueLength,
+    );
+  }
+}

--- a/pchaa/pchaa_server/lib/src/generated/order_with_estimated.dart
+++ b/pchaa/pchaa_server/lib/src/generated/order_with_estimated.dart
@@ -1,0 +1,127 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import 'orders.dart' as _i2;
+import 'order_items.dart' as _i3;
+import 'package:pchaa_server/src/generated/protocol.dart' as _i4;
+
+abstract class OrderWithEstimated
+    implements _i1.SerializableModel, _i1.ProtocolSerialization {
+  OrderWithEstimated._({
+    required this.order,
+    required this.orderItems,
+    this.estimatedPrepTime,
+    this.queueLength,
+  });
+
+  factory OrderWithEstimated({
+    required _i2.Order order,
+    required List<_i3.OrderItem> orderItems,
+    int? estimatedPrepTime,
+    int? queueLength,
+  }) = _OrderWithEstimatedImpl;
+
+  factory OrderWithEstimated.fromJson(Map<String, dynamic> jsonSerialization) {
+    return OrderWithEstimated(
+      order: _i4.Protocol().deserialize<_i2.Order>(jsonSerialization['order']),
+      orderItems: _i4.Protocol().deserialize<List<_i3.OrderItem>>(
+        jsonSerialization['orderItems'],
+      ),
+      estimatedPrepTime: jsonSerialization['estimatedPrepTime'] as int?,
+      queueLength: jsonSerialization['queueLength'] as int?,
+    );
+  }
+
+  _i2.Order order;
+
+  List<_i3.OrderItem> orderItems;
+
+  int? estimatedPrepTime;
+
+  int? queueLength;
+
+  /// Returns a shallow copy of this [OrderWithEstimated]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  OrderWithEstimated copyWith({
+    _i2.Order? order,
+    List<_i3.OrderItem>? orderItems,
+    int? estimatedPrepTime,
+    int? queueLength,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'OrderWithEstimated',
+      'order': order.toJson(),
+      'orderItems': orderItems.toJson(valueToJson: (v) => v.toJson()),
+      if (estimatedPrepTime != null) 'estimatedPrepTime': estimatedPrepTime,
+      if (queueLength != null) 'queueLength': queueLength,
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {
+      '__className__': 'OrderWithEstimated',
+      'order': order.toJsonForProtocol(),
+      'orderItems': orderItems.toJson(
+        valueToJson: (v) => v.toJsonForProtocol(),
+      ),
+      if (estimatedPrepTime != null) 'estimatedPrepTime': estimatedPrepTime,
+      if (queueLength != null) 'queueLength': queueLength,
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _OrderWithEstimatedImpl extends OrderWithEstimated {
+  _OrderWithEstimatedImpl({
+    required _i2.Order order,
+    required List<_i3.OrderItem> orderItems,
+    int? estimatedPrepTime,
+    int? queueLength,
+  }) : super._(
+         order: order,
+         orderItems: orderItems,
+         estimatedPrepTime: estimatedPrepTime,
+         queueLength: queueLength,
+       );
+
+  /// Returns a shallow copy of this [OrderWithEstimated]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  OrderWithEstimated copyWith({
+    _i2.Order? order,
+    List<_i3.OrderItem>? orderItems,
+    Object? estimatedPrepTime = _Undefined,
+    Object? queueLength = _Undefined,
+  }) {
+    return OrderWithEstimated(
+      order: order ?? this.order.copyWith(),
+      orderItems:
+          orderItems ?? this.orderItems.map((e0) => e0.copyWith()).toList(),
+      estimatedPrepTime: estimatedPrepTime is int?
+          ? estimatedPrepTime
+          : this.estimatedPrepTime,
+      queueLength: queueLength is int? ? queueLength : this.queueLength,
+    );
+  }
+}

--- a/pchaa/pchaa_server/lib/src/generated/protocol.dart
+++ b/pchaa/pchaa_server/lib/src/generated/protocol.dart
@@ -25,30 +25,32 @@ import 'cart_detail.dart' as _i10;
 import 'carts.dart' as _i11;
 import 'customization_group.dart' as _i12;
 import 'daily_queue_counters.dart' as _i13;
-import 'fcm_token.dart' as _i14;
-import 'greetings/greeting.dart' as _i15;
-import 'ingredient.dart' as _i16;
-import 'menu_item_with_url.dart' as _i17;
-import 'menu_items.dart' as _i18;
-import 'order_items.dart' as _i19;
-import 'order_status.dart' as _i20;
-import 'order_type.dart' as _i21;
-import 'order_with_user_name.dart' as _i22;
-import 'orders.dart' as _i23;
-import 'selected_option.dart' as _i24;
-import 'store_settings.dart' as _i25;
-import 'user_role.dart' as _i26;
-import 'users.dart' as _i27;
-import 'package:pchaa_server/src/generated/cart_detail.dart' as _i28;
-import 'package:pchaa_server/src/generated/selected_option.dart' as _i29;
-import 'package:pchaa_server/src/generated/ingredient.dart' as _i30;
-import 'package:pchaa_server/src/generated/customization_group.dart' as _i31;
-import 'package:pchaa_server/src/generated/menu_item_with_url.dart' as _i32;
-import 'package:pchaa_server/src/generated/available_menu_item.dart' as _i33;
-import 'package:pchaa_server/src/generated/orders.dart' as _i34;
-import 'package:pchaa_server/src/generated/order_items.dart' as _i35;
-import 'package:pchaa_server/src/generated/order_with_user_name.dart' as _i36;
-import 'package:pchaa_server/src/generated/users.dart' as _i37;
+import 'estimated_queue.dart' as _i14;
+import 'fcm_token.dart' as _i15;
+import 'greetings/greeting.dart' as _i16;
+import 'ingredient.dart' as _i17;
+import 'menu_item_with_url.dart' as _i18;
+import 'menu_items.dart' as _i19;
+import 'order_items.dart' as _i20;
+import 'order_status.dart' as _i21;
+import 'order_type.dart' as _i22;
+import 'order_with_estimated.dart' as _i23;
+import 'order_with_user_name.dart' as _i24;
+import 'orders.dart' as _i25;
+import 'selected_option.dart' as _i26;
+import 'store_settings.dart' as _i27;
+import 'user_role.dart' as _i28;
+import 'users.dart' as _i29;
+import 'package:pchaa_server/src/generated/cart_detail.dart' as _i30;
+import 'package:pchaa_server/src/generated/selected_option.dart' as _i31;
+import 'package:pchaa_server/src/generated/ingredient.dart' as _i32;
+import 'package:pchaa_server/src/generated/customization_group.dart' as _i33;
+import 'package:pchaa_server/src/generated/menu_item_with_url.dart' as _i34;
+import 'package:pchaa_server/src/generated/available_menu_item.dart' as _i35;
+import 'package:pchaa_server/src/generated/orders.dart' as _i36;
+import 'package:pchaa_server/src/generated/order_items.dart' as _i37;
+import 'package:pchaa_server/src/generated/order_with_user_name.dart' as _i38;
+import 'package:pchaa_server/src/generated/users.dart' as _i39;
 export 'add_on_option.dart';
 export 'available_add_on_option.dart';
 export 'available_customization_group.dart';
@@ -57,6 +59,7 @@ export 'cart_detail.dart';
 export 'carts.dart';
 export 'customization_group.dart';
 export 'daily_queue_counters.dart';
+export 'estimated_queue.dart';
 export 'fcm_token.dart';
 export 'greetings/greeting.dart';
 export 'ingredient.dart';
@@ -65,6 +68,7 @@ export 'menu_items.dart';
 export 'order_items.dart';
 export 'order_status.dart';
 export 'order_type.dart';
+export 'order_with_estimated.dart';
 export 'order_with_user_name.dart';
 export 'orders.dart';
 export 'selected_option.dart';
@@ -755,47 +759,53 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i13.DailyQueueCounter) {
       return _i13.DailyQueueCounter.fromJson(data) as T;
     }
-    if (t == _i14.FcmToken) {
-      return _i14.FcmToken.fromJson(data) as T;
+    if (t == _i14.EstimatedQueue) {
+      return _i14.EstimatedQueue.fromJson(data) as T;
     }
-    if (t == _i15.Greeting) {
-      return _i15.Greeting.fromJson(data) as T;
+    if (t == _i15.FcmToken) {
+      return _i15.FcmToken.fromJson(data) as T;
     }
-    if (t == _i16.Ingredient) {
-      return _i16.Ingredient.fromJson(data) as T;
+    if (t == _i16.Greeting) {
+      return _i16.Greeting.fromJson(data) as T;
     }
-    if (t == _i17.MenuItemWithUrl) {
-      return _i17.MenuItemWithUrl.fromJson(data) as T;
+    if (t == _i17.Ingredient) {
+      return _i17.Ingredient.fromJson(data) as T;
     }
-    if (t == _i18.MenuItem) {
-      return _i18.MenuItem.fromJson(data) as T;
+    if (t == _i18.MenuItemWithUrl) {
+      return _i18.MenuItemWithUrl.fromJson(data) as T;
     }
-    if (t == _i19.OrderItem) {
-      return _i19.OrderItem.fromJson(data) as T;
+    if (t == _i19.MenuItem) {
+      return _i19.MenuItem.fromJson(data) as T;
     }
-    if (t == _i20.OrderStatus) {
-      return _i20.OrderStatus.fromJson(data) as T;
+    if (t == _i20.OrderItem) {
+      return _i20.OrderItem.fromJson(data) as T;
     }
-    if (t == _i21.OrderType) {
-      return _i21.OrderType.fromJson(data) as T;
+    if (t == _i21.OrderStatus) {
+      return _i21.OrderStatus.fromJson(data) as T;
     }
-    if (t == _i22.OrderWithUserName) {
-      return _i22.OrderWithUserName.fromJson(data) as T;
+    if (t == _i22.OrderType) {
+      return _i22.OrderType.fromJson(data) as T;
     }
-    if (t == _i23.Order) {
-      return _i23.Order.fromJson(data) as T;
+    if (t == _i23.OrderWithEstimated) {
+      return _i23.OrderWithEstimated.fromJson(data) as T;
     }
-    if (t == _i24.SelectedOption) {
-      return _i24.SelectedOption.fromJson(data) as T;
+    if (t == _i24.OrderWithUserName) {
+      return _i24.OrderWithUserName.fromJson(data) as T;
     }
-    if (t == _i25.StoreSettings) {
-      return _i25.StoreSettings.fromJson(data) as T;
+    if (t == _i25.Order) {
+      return _i25.Order.fromJson(data) as T;
     }
-    if (t == _i26.UserRole) {
-      return _i26.UserRole.fromJson(data) as T;
+    if (t == _i26.SelectedOption) {
+      return _i26.SelectedOption.fromJson(data) as T;
     }
-    if (t == _i27.User) {
-      return _i27.User.fromJson(data) as T;
+    if (t == _i27.StoreSettings) {
+      return _i27.StoreSettings.fromJson(data) as T;
+    }
+    if (t == _i28.UserRole) {
+      return _i28.UserRole.fromJson(data) as T;
+    }
+    if (t == _i29.User) {
+      return _i29.User.fromJson(data) as T;
     }
     if (t == _i1.getType<_i6.AddOnOption?>()) {
       return (data != null ? _i6.AddOnOption.fromJson(data) : null) as T;
@@ -826,47 +836,54 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<_i13.DailyQueueCounter?>()) {
       return (data != null ? _i13.DailyQueueCounter.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i14.FcmToken?>()) {
-      return (data != null ? _i14.FcmToken.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i14.EstimatedQueue?>()) {
+      return (data != null ? _i14.EstimatedQueue.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i15.Greeting?>()) {
-      return (data != null ? _i15.Greeting.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i15.FcmToken?>()) {
+      return (data != null ? _i15.FcmToken.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i16.Ingredient?>()) {
-      return (data != null ? _i16.Ingredient.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i16.Greeting?>()) {
+      return (data != null ? _i16.Greeting.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i17.MenuItemWithUrl?>()) {
-      return (data != null ? _i17.MenuItemWithUrl.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i17.Ingredient?>()) {
+      return (data != null ? _i17.Ingredient.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i18.MenuItem?>()) {
-      return (data != null ? _i18.MenuItem.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i18.MenuItemWithUrl?>()) {
+      return (data != null ? _i18.MenuItemWithUrl.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i19.OrderItem?>()) {
-      return (data != null ? _i19.OrderItem.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i19.MenuItem?>()) {
+      return (data != null ? _i19.MenuItem.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i20.OrderStatus?>()) {
-      return (data != null ? _i20.OrderStatus.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i20.OrderItem?>()) {
+      return (data != null ? _i20.OrderItem.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i21.OrderType?>()) {
-      return (data != null ? _i21.OrderType.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i21.OrderStatus?>()) {
+      return (data != null ? _i21.OrderStatus.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i22.OrderWithUserName?>()) {
-      return (data != null ? _i22.OrderWithUserName.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i22.OrderType?>()) {
+      return (data != null ? _i22.OrderType.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i23.Order?>()) {
-      return (data != null ? _i23.Order.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i23.OrderWithEstimated?>()) {
+      return (data != null ? _i23.OrderWithEstimated.fromJson(data) : null)
+          as T;
     }
-    if (t == _i1.getType<_i24.SelectedOption?>()) {
-      return (data != null ? _i24.SelectedOption.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i24.OrderWithUserName?>()) {
+      return (data != null ? _i24.OrderWithUserName.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i25.StoreSettings?>()) {
-      return (data != null ? _i25.StoreSettings.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i25.Order?>()) {
+      return (data != null ? _i25.Order.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i26.UserRole?>()) {
-      return (data != null ? _i26.UserRole.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i26.SelectedOption?>()) {
+      return (data != null ? _i26.SelectedOption.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i27.User?>()) {
-      return (data != null ? _i27.User.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i27.StoreSettings?>()) {
+      return (data != null ? _i27.StoreSettings.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i28.UserRole?>()) {
+      return (data != null ? _i28.UserRole.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i29.User?>()) {
+      return (data != null ? _i29.User.fromJson(data) : null) as T;
     }
     if (t == List<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toList() as T;
@@ -889,9 +906,9 @@ class Protocol extends _i1.SerializationManagerServer {
               .toList()
           as T;
     }
-    if (t == List<_i24.SelectedOption>) {
+    if (t == List<_i26.SelectedOption>) {
       return (data as List)
-              .map((e) => deserialize<_i24.SelectedOption>(e))
+              .map((e) => deserialize<_i26.SelectedOption>(e))
               .toList()
           as T;
     }
@@ -905,23 +922,27 @@ class Protocol extends _i1.SerializationManagerServer {
               .toList()
           as T;
     }
-    if (t == List<_i28.CartDetail>) {
-      return (data as List).map((e) => deserialize<_i28.CartDetail>(e)).toList()
+    if (t == List<_i20.OrderItem>) {
+      return (data as List).map((e) => deserialize<_i20.OrderItem>(e)).toList()
           as T;
     }
-    if (t == List<_i29.SelectedOption>) {
+    if (t == List<_i30.CartDetail>) {
+      return (data as List).map((e) => deserialize<_i30.CartDetail>(e)).toList()
+          as T;
+    }
+    if (t == List<_i31.SelectedOption>) {
       return (data as List)
-              .map((e) => deserialize<_i29.SelectedOption>(e))
+              .map((e) => deserialize<_i31.SelectedOption>(e))
               .toList()
           as T;
     }
-    if (t == List<_i30.Ingredient>) {
-      return (data as List).map((e) => deserialize<_i30.Ingredient>(e)).toList()
+    if (t == List<_i32.Ingredient>) {
+      return (data as List).map((e) => deserialize<_i32.Ingredient>(e)).toList()
           as T;
     }
-    if (t == List<_i31.CustomizationGroup>) {
+    if (t == List<_i33.CustomizationGroup>) {
       return (data as List)
-              .map((e) => deserialize<_i31.CustomizationGroup>(e))
+              .map((e) => deserialize<_i33.CustomizationGroup>(e))
               .toList()
           as T;
     }
@@ -934,28 +955,38 @@ class Protocol extends _i1.SerializationManagerServer {
               : null)
           as T;
     }
-    if (t == List<_i32.MenuItemWithUrl>) {
+    if (t == List<_i34.MenuItemWithUrl>) {
       return (data as List)
-              .map((e) => deserialize<_i32.MenuItemWithUrl>(e))
+              .map((e) => deserialize<_i34.MenuItemWithUrl>(e))
               .toList()
           as T;
     }
-    if (t == List<_i33.AvailableMenuItem>) {
+    if (t == List<_i35.AvailableMenuItem>) {
       return (data as List)
-              .map((e) => deserialize<_i33.AvailableMenuItem>(e))
+              .map((e) => deserialize<_i35.AvailableMenuItem>(e))
               .toList()
           as T;
     }
-    if (t == _i1.getType<List<_i31.CustomizationGroup>?>()) {
+    if (t == _i1.getType<List<_i33.CustomizationGroup>?>()) {
       return (data != null
               ? (data as List)
-                    .map((e) => deserialize<_i31.CustomizationGroup>(e))
+                    .map((e) => deserialize<_i33.CustomizationGroup>(e))
                     .toList()
               : null)
           as T;
     }
-    if (t == List<_i34.Order>) {
-      return (data as List).map((e) => deserialize<_i34.Order>(e)).toList()
+    if (t == List<_i36.Order>) {
+      return (data as List).map((e) => deserialize<_i36.Order>(e)).toList()
+          as T;
+    }
+    if (t == List<_i37.OrderItem>) {
+      return (data as List).map((e) => deserialize<_i37.OrderItem>(e)).toList()
+          as T;
+    }
+    if (t == List<_i38.OrderWithUserName>) {
+      return (data as List)
+              .map((e) => deserialize<_i38.OrderWithUserName>(e))
+              .toList()
           as T;
     }
     if (t == Map<String, int>) {
@@ -964,28 +995,12 @@ class Protocol extends _i1.SerializationManagerServer {
           )
           as T;
     }
-    if (t == Map<String, dynamic>) {
-      return (data as Map).map(
-            (k, v) => MapEntry(deserialize<String>(k), deserialize<dynamic>(v)),
-          )
-          as T;
+    if (t == List<_i39.User>) {
+      return (data as List).map((e) => deserialize<_i39.User>(e)).toList() as T;
     }
-    if (t == List<_i35.OrderItem>) {
-      return (data as List).map((e) => deserialize<_i35.OrderItem>(e)).toList()
-          as T;
-    }
-    if (t == List<_i36.OrderWithUserName>) {
-      return (data as List)
-              .map((e) => deserialize<_i36.OrderWithUserName>(e))
-              .toList()
-          as T;
-    }
-    if (t == List<_i37.User>) {
-      return (data as List).map((e) => deserialize<_i37.User>(e)).toList() as T;
-    }
-    if (t == _i1.getType<List<_i37.User>?>()) {
+    if (t == _i1.getType<List<_i39.User>?>()) {
       return (data != null
-              ? (data as List).map((e) => deserialize<_i37.User>(e)).toList()
+              ? (data as List).map((e) => deserialize<_i39.User>(e)).toList()
               : null)
           as T;
     }
@@ -1014,20 +1029,22 @@ class Protocol extends _i1.SerializationManagerServer {
       _i11.Cart => 'Cart',
       _i12.CustomizationGroup => 'CustomizationGroup',
       _i13.DailyQueueCounter => 'DailyQueueCounter',
-      _i14.FcmToken => 'FcmToken',
-      _i15.Greeting => 'Greeting',
-      _i16.Ingredient => 'Ingredient',
-      _i17.MenuItemWithUrl => 'MenuItemWithUrl',
-      _i18.MenuItem => 'MenuItem',
-      _i19.OrderItem => 'OrderItem',
-      _i20.OrderStatus => 'OrderStatus',
-      _i21.OrderType => 'OrderType',
-      _i22.OrderWithUserName => 'OrderWithUserName',
-      _i23.Order => 'Order',
-      _i24.SelectedOption => 'SelectedOption',
-      _i25.StoreSettings => 'StoreSettings',
-      _i26.UserRole => 'UserRole',
-      _i27.User => 'User',
+      _i14.EstimatedQueue => 'EstimatedQueue',
+      _i15.FcmToken => 'FcmToken',
+      _i16.Greeting => 'Greeting',
+      _i17.Ingredient => 'Ingredient',
+      _i18.MenuItemWithUrl => 'MenuItemWithUrl',
+      _i19.MenuItem => 'MenuItem',
+      _i20.OrderItem => 'OrderItem',
+      _i21.OrderStatus => 'OrderStatus',
+      _i22.OrderType => 'OrderType',
+      _i23.OrderWithEstimated => 'OrderWithEstimated',
+      _i24.OrderWithUserName => 'OrderWithUserName',
+      _i25.Order => 'Order',
+      _i26.SelectedOption => 'SelectedOption',
+      _i27.StoreSettings => 'StoreSettings',
+      _i28.UserRole => 'UserRole',
+      _i29.User => 'User',
       _ => null,
     };
   }
@@ -1058,33 +1075,37 @@ class Protocol extends _i1.SerializationManagerServer {
         return 'CustomizationGroup';
       case _i13.DailyQueueCounter():
         return 'DailyQueueCounter';
-      case _i14.FcmToken():
+      case _i14.EstimatedQueue():
+        return 'EstimatedQueue';
+      case _i15.FcmToken():
         return 'FcmToken';
-      case _i15.Greeting():
+      case _i16.Greeting():
         return 'Greeting';
-      case _i16.Ingredient():
+      case _i17.Ingredient():
         return 'Ingredient';
-      case _i17.MenuItemWithUrl():
+      case _i18.MenuItemWithUrl():
         return 'MenuItemWithUrl';
-      case _i18.MenuItem():
+      case _i19.MenuItem():
         return 'MenuItem';
-      case _i19.OrderItem():
+      case _i20.OrderItem():
         return 'OrderItem';
-      case _i20.OrderStatus():
+      case _i21.OrderStatus():
         return 'OrderStatus';
-      case _i21.OrderType():
+      case _i22.OrderType():
         return 'OrderType';
-      case _i22.OrderWithUserName():
+      case _i23.OrderWithEstimated():
+        return 'OrderWithEstimated';
+      case _i24.OrderWithUserName():
         return 'OrderWithUserName';
-      case _i23.Order():
+      case _i25.Order():
         return 'Order';
-      case _i24.SelectedOption():
+      case _i26.SelectedOption():
         return 'SelectedOption';
-      case _i25.StoreSettings():
+      case _i27.StoreSettings():
         return 'StoreSettings';
-      case _i26.UserRole():
+      case _i28.UserRole():
         return 'UserRole';
-      case _i27.User():
+      case _i29.User():
         return 'User';
     }
     className = _i2.Protocol().getClassNameForObject(data);
@@ -1136,47 +1157,53 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'DailyQueueCounter') {
       return deserialize<_i13.DailyQueueCounter>(data['data']);
     }
+    if (dataClassName == 'EstimatedQueue') {
+      return deserialize<_i14.EstimatedQueue>(data['data']);
+    }
     if (dataClassName == 'FcmToken') {
-      return deserialize<_i14.FcmToken>(data['data']);
+      return deserialize<_i15.FcmToken>(data['data']);
     }
     if (dataClassName == 'Greeting') {
-      return deserialize<_i15.Greeting>(data['data']);
+      return deserialize<_i16.Greeting>(data['data']);
     }
     if (dataClassName == 'Ingredient') {
-      return deserialize<_i16.Ingredient>(data['data']);
+      return deserialize<_i17.Ingredient>(data['data']);
     }
     if (dataClassName == 'MenuItemWithUrl') {
-      return deserialize<_i17.MenuItemWithUrl>(data['data']);
+      return deserialize<_i18.MenuItemWithUrl>(data['data']);
     }
     if (dataClassName == 'MenuItem') {
-      return deserialize<_i18.MenuItem>(data['data']);
+      return deserialize<_i19.MenuItem>(data['data']);
     }
     if (dataClassName == 'OrderItem') {
-      return deserialize<_i19.OrderItem>(data['data']);
+      return deserialize<_i20.OrderItem>(data['data']);
     }
     if (dataClassName == 'OrderStatus') {
-      return deserialize<_i20.OrderStatus>(data['data']);
+      return deserialize<_i21.OrderStatus>(data['data']);
     }
     if (dataClassName == 'OrderType') {
-      return deserialize<_i21.OrderType>(data['data']);
+      return deserialize<_i22.OrderType>(data['data']);
+    }
+    if (dataClassName == 'OrderWithEstimated') {
+      return deserialize<_i23.OrderWithEstimated>(data['data']);
     }
     if (dataClassName == 'OrderWithUserName') {
-      return deserialize<_i22.OrderWithUserName>(data['data']);
+      return deserialize<_i24.OrderWithUserName>(data['data']);
     }
     if (dataClassName == 'Order') {
-      return deserialize<_i23.Order>(data['data']);
+      return deserialize<_i25.Order>(data['data']);
     }
     if (dataClassName == 'SelectedOption') {
-      return deserialize<_i24.SelectedOption>(data['data']);
+      return deserialize<_i26.SelectedOption>(data['data']);
     }
     if (dataClassName == 'StoreSettings') {
-      return deserialize<_i25.StoreSettings>(data['data']);
+      return deserialize<_i27.StoreSettings>(data['data']);
     }
     if (dataClassName == 'UserRole') {
-      return deserialize<_i26.UserRole>(data['data']);
+      return deserialize<_i28.UserRole>(data['data']);
     }
     if (dataClassName == 'User') {
-      return deserialize<_i27.User>(data['data']);
+      return deserialize<_i29.User>(data['data']);
     }
     if (dataClassName.startsWith('serverpod.')) {
       data['className'] = dataClassName.substring(10);
@@ -1228,20 +1255,20 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i11.Cart.t;
       case _i13.DailyQueueCounter:
         return _i13.DailyQueueCounter.t;
-      case _i14.FcmToken:
-        return _i14.FcmToken.t;
-      case _i16.Ingredient:
-        return _i16.Ingredient.t;
-      case _i18.MenuItem:
-        return _i18.MenuItem.t;
-      case _i19.OrderItem:
-        return _i19.OrderItem.t;
-      case _i23.Order:
-        return _i23.Order.t;
-      case _i25.StoreSettings:
-        return _i25.StoreSettings.t;
-      case _i27.User:
-        return _i27.User.t;
+      case _i15.FcmToken:
+        return _i15.FcmToken.t;
+      case _i17.Ingredient:
+        return _i17.Ingredient.t;
+      case _i19.MenuItem:
+        return _i19.MenuItem.t;
+      case _i20.OrderItem:
+        return _i20.OrderItem.t;
+      case _i25.Order:
+        return _i25.Order.t;
+      case _i27.StoreSettings:
+        return _i27.StoreSettings.t;
+      case _i29.User:
+        return _i29.User.t;
     }
     return null;
   }

--- a/pchaa/pchaa_server/lib/src/generated/protocol.yaml
+++ b/pchaa/pchaa_server/lib/src/generated/protocol.yaml
@@ -43,6 +43,7 @@ order:
   - getOrderById:
   - getOrderItems:
   - getTodayOrder:
+  - getFinishedOrder:
 queue:
   - getQueueCounters:
 store:

--- a/pchaa/pchaa_server/lib/src/models/estimated_queue.yaml
+++ b/pchaa/pchaa_server/lib/src/models/estimated_queue.yaml
@@ -1,0 +1,4 @@
+class: EstimatedQueue
+fields:
+  estimatedPrepTime: int
+  queueLength: int

--- a/pchaa/pchaa_server/lib/src/models/order_with_estimated.yaml
+++ b/pchaa/pchaa_server/lib/src/models/order_with_estimated.yaml
@@ -1,0 +1,6 @@
+class: OrderWithEstimated
+fields:
+  order: Order
+  orderItems: List<OrderItem>
+  estimatedPrepTime: int?
+  queueLength: int?

--- a/pchaa/pchaa_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/pchaa/pchaa_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -28,12 +28,14 @@ import 'package:pchaa_server/src/generated/available_menu_item.dart' as _i12;
 import 'package:pchaa_server/src/generated/orders.dart' as _i13;
 import 'package:pchaa_server/src/generated/order_type.dart' as _i14;
 import 'package:pchaa_server/src/generated/order_status.dart' as _i15;
-import 'package:pchaa_server/src/generated/order_items.dart' as _i16;
-import 'package:pchaa_server/src/generated/order_with_user_name.dart' as _i17;
-import 'package:pchaa_server/src/generated/store_settings.dart' as _i18;
-import 'package:pchaa_server/src/generated/users.dart' as _i19;
-import 'package:pchaa_server/src/generated/user_role.dart' as _i20;
-import 'package:pchaa_server/src/generated/greetings/greeting.dart' as _i21;
+import 'package:pchaa_server/src/generated/estimated_queue.dart' as _i16;
+import 'package:pchaa_server/src/generated/order_with_estimated.dart' as _i17;
+import 'package:pchaa_server/src/generated/order_items.dart' as _i18;
+import 'package:pchaa_server/src/generated/order_with_user_name.dart' as _i19;
+import 'package:pchaa_server/src/generated/store_settings.dart' as _i20;
+import 'package:pchaa_server/src/generated/users.dart' as _i21;
+import 'package:pchaa_server/src/generated/user_role.dart' as _i22;
+import 'package:pchaa_server/src/generated/greetings/greeting.dart' as _i23;
 import 'package:pchaa_server/src/generated/protocol.dart';
 import 'package:pchaa_server/src/generated/endpoints.dart';
 export 'package:serverpod_test/serverpod_test_public_exports.dart';
@@ -1439,7 +1441,7 @@ class _OrderEndpoint {
     });
   }
 
-  _i3.Future<Map<String, int>> getEstimatedQueue(
+  _i3.Future<_i16.EstimatedQueue> getEstimatedQueue(
     _i1.TestSessionBuilder sessionBuilder,
   ) async {
     return _i1.callAwaitableFunctionAndHandleExceptions(() async {
@@ -1461,7 +1463,7 @@ class _OrderEndpoint {
                   _localUniqueSession,
                   _localCallContext.arguments,
                 )
-                as _i3.Future<Map<String, int>>);
+                as _i3.Future<_i16.EstimatedQueue>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();
@@ -1469,7 +1471,7 @@ class _OrderEndpoint {
     });
   }
 
-  _i3.Future<Map<String, dynamic>> getOrderById(
+  _i3.Future<_i17.OrderWithEstimated> getOrderById(
     _i1.TestSessionBuilder sessionBuilder,
     int orderId,
   ) async {
@@ -1492,7 +1494,7 @@ class _OrderEndpoint {
                   _localUniqueSession,
                   _localCallContext.arguments,
                 )
-                as _i3.Future<Map<String, dynamic>>);
+                as _i3.Future<_i17.OrderWithEstimated>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();
@@ -1500,7 +1502,7 @@ class _OrderEndpoint {
     });
   }
 
-  _i3.Future<List<_i16.OrderItem>> getOrderItems(
+  _i3.Future<List<_i18.OrderItem>> getOrderItems(
     _i1.TestSessionBuilder sessionBuilder,
     int orderId,
   ) async {
@@ -1523,7 +1525,7 @@ class _OrderEndpoint {
                   _localUniqueSession,
                   _localCallContext.arguments,
                 )
-                as _i3.Future<List<_i16.OrderItem>>);
+                as _i3.Future<List<_i18.OrderItem>>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();
@@ -1531,7 +1533,7 @@ class _OrderEndpoint {
     });
   }
 
-  _i3.Future<List<_i17.OrderWithUserName>> getTodayOrder(
+  _i3.Future<List<_i19.OrderWithUserName>> getTodayOrder(
     _i1.TestSessionBuilder sessionBuilder,
   ) async {
     return _i1.callAwaitableFunctionAndHandleExceptions(() async {
@@ -1553,7 +1555,37 @@ class _OrderEndpoint {
                   _localUniqueSession,
                   _localCallContext.arguments,
                 )
-                as _i3.Future<List<_i17.OrderWithUserName>>);
+                as _i3.Future<List<_i19.OrderWithUserName>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<List<_i19.OrderWithUserName>> getFinishedOrder(
+    _i1.TestSessionBuilder sessionBuilder,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'order',
+            method: 'getFinishedOrder',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'order',
+          methodName: 'getFinishedOrder',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<List<_i19.OrderWithUserName>>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();
@@ -1613,7 +1645,7 @@ class _StoreEndpoint {
 
   final _i2.SerializationManager _serializationManager;
 
-  _i3.Future<_i18.StoreSettings> getStoreSettings(
+  _i3.Future<_i20.StoreSettings> getStoreSettings(
     _i1.TestSessionBuilder sessionBuilder,
   ) async {
     return _i1.callAwaitableFunctionAndHandleExceptions(() async {
@@ -1635,7 +1667,7 @@ class _StoreEndpoint {
                   _localUniqueSession,
                   _localCallContext.arguments,
                 )
-                as _i3.Future<_i18.StoreSettings>);
+                as _i3.Future<_i20.StoreSettings>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();
@@ -1676,7 +1708,7 @@ class _StoreEndpoint {
 
   _i3.Future<void> updateStoreSettings(
     _i1.TestSessionBuilder sessionBuilder,
-    _i18.StoreSettings storeSettings,
+    _i20.StoreSettings storeSettings,
   ) async {
     return _i1.callAwaitableFunctionAndHandleExceptions(() async {
       var _localUniqueSession =
@@ -1716,7 +1748,7 @@ class _UserEndpoint {
 
   final _i2.SerializationManager _serializationManager;
 
-  _i3.Future<_i19.User?> registerUser(
+  _i3.Future<_i21.User?> registerUser(
     _i1.TestSessionBuilder sessionBuilder, {
     String? profilePictureUrl,
   }) async {
@@ -1741,7 +1773,7 @@ class _UserEndpoint {
                   _localUniqueSession,
                   _localCallContext.arguments,
                 )
-                as _i3.Future<_i19.User?>);
+                as _i3.Future<_i21.User?>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();
@@ -1749,7 +1781,7 @@ class _UserEndpoint {
     });
   }
 
-  _i3.Future<_i19.User?> getCurrentUser(
+  _i3.Future<_i21.User?> getCurrentUser(
     _i1.TestSessionBuilder sessionBuilder,
   ) async {
     return _i1.callAwaitableFunctionAndHandleExceptions(() async {
@@ -1771,7 +1803,7 @@ class _UserEndpoint {
                   _localUniqueSession,
                   _localCallContext.arguments,
                 )
-                as _i3.Future<_i19.User?>);
+                as _i3.Future<_i21.User?>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();
@@ -1779,7 +1811,7 @@ class _UserEndpoint {
     });
   }
 
-  _i3.Future<List<_i19.User>?> getAllUser(
+  _i3.Future<List<_i21.User>?> getAllUser(
     _i1.TestSessionBuilder sessionBuilder,
   ) async {
     return _i1.callAwaitableFunctionAndHandleExceptions(() async {
@@ -1801,7 +1833,7 @@ class _UserEndpoint {
                   _localUniqueSession,
                   _localCallContext.arguments,
                 )
-                as _i3.Future<List<_i19.User>?>);
+                as _i3.Future<List<_i21.User>?>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();
@@ -1809,10 +1841,10 @@ class _UserEndpoint {
     });
   }
 
-  _i3.Future<_i19.User> updateUserRole(
+  _i3.Future<_i21.User> updateUserRole(
     _i1.TestSessionBuilder sessionBuilder,
     int userId,
-    _i20.UserRole newRole,
+    _i22.UserRole newRole,
   ) async {
     return _i1.callAwaitableFunctionAndHandleExceptions(() async {
       var _localUniqueSession =
@@ -1836,7 +1868,7 @@ class _UserEndpoint {
                   _localUniqueSession,
                   _localCallContext.arguments,
                 )
-                as _i3.Future<_i19.User>);
+                as _i3.Future<_i21.User>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();
@@ -1855,7 +1887,7 @@ class _GreetingEndpoint {
 
   final _i2.SerializationManager _serializationManager;
 
-  _i3.Future<_i21.Greeting> hello(
+  _i3.Future<_i23.Greeting> hello(
     _i1.TestSessionBuilder sessionBuilder,
     String name,
   ) async {
@@ -1878,7 +1910,7 @@ class _GreetingEndpoint {
                   _localUniqueSession,
                   _localCallContext.arguments,
                 )
-                as _i3.Future<_i21.Greeting>);
+                as _i3.Future<_i23.Greeting>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();


### PR DESCRIPTION
This pull request introduces new models for estimated queue and order details with estimated preparation time, and updates the client protocol to use these new types. It also refactors various endpoint methods to improve data structure consistency and adds support for fetching finished orders. The changes are primarily aimed at enhancing how queue and order information is represented and retrieved in the client.

**New models and exports:**

* Added the `EstimatedQueue` model (`estimated_queue.dart`) to represent estimated preparation time and queue length.
* Added the `OrderWithEstimated` model (`order_with_estimated.dart`) to encapsulate order details along with estimated preparation time and queue length.

**Protocol and endpoint refactoring:**

* Updated the serialization logic in `protocol.dart` to register and deserialize the new models, and refactored import references to use the new types.
* Refactored endpoint methods in `client.dart` to use the new models (`EstimatedQueue`, `OrderWithEstimated`, etc.) instead of generic maps, improving type safety and clarity.

**Order and store endpoints:**

* Added a new method `getFinishedOrder` to the order endpoint to fetch finished orders.
* Updated store and user endpoint methods to use the correct model references after the protocol changes. 
**Miscellaneous updates:**

* Adjusted module and client initialization logic to accommodate the new protocol structure and imports. 